### PR TITLE
Show full text of a retweet. Fixes issue #3

### DIFF
--- a/dazeus-twitterd.pl
+++ b/dazeus-twitterd.pl
@@ -96,8 +96,13 @@ while(1) {
 	}
 	my @statuses = reverse @$statuses;
 	for my $status(@statuses) {
-		my $body = "-Twitter- <" . $status->{user}{screen_name}
-			   . "> " . decode_entities ($status->{text});
+		my $body = "-Twitter- <" . $status->{user}{screen_name} . "> ";
+		if ($status->{retweeted_status}) {
+			$body .= "RT @" . $status->{retweeted_status}{user}{screen_name} . ": "
+			. decode_entities($status->{retweeted_status}{text});
+		} else {
+			$body .= decode_entities ($status->{text});
+		}
 		print "$body\n" unless $QUIET;
 		eval {
 			my $result = $dazeus->message($NETWORK, $CHANNEL, $body);


### PR DESCRIPTION
--- ORIGINAL ISSUE ---
Currently, retweets from a list such as

``` json
{
"text": "RT @GreatFireChina: Github suffered man in the middle attack in China! SSL certificate is self-signed when accessing from China! http:// ...",
"truncated": false
}
```

are truncated by the Twitter API. The original message is packed in another JSON object, which is only included in retweeted statuses:

``` json
"retweeted_status":  {
      "text": "Github suffered man in the middle attack in China! SSL certificate is self-signed when accessing from China! http://t.co/8wWeEKR5",
      "truncated": false,
}
```

This is an issue in Net::Twitter::Lite, but there might be a chance a workaround can be made within this plugin.
