### PR TITLE
SSL for dazeus-twitterd.pl

### DIFF
--- a/dazeus-twitterd.pl
+++ b/dazeus-twitterd.pl
@@ -67,6 +67,7 @@ my $net_twitter = new Net::Twitter::Lite::WithAPIv1_1(
 	consumer_secret => $opt->secret,
 	access_token => $opt->token,
 	access_token_secret => $opt->token_secret,
+	ssl => 1,
 );
 my $dazeus      = DaZeus->connect($opt->sock);
 if(!$dazeus) {


### PR DESCRIPTION
Use SSL for API calls. Required as of 14 January 2014
