### PR TITLE
Do not include the shortened url after expanding

### DIFF
--- a/dazeus-twitterd.pl
+++ b/dazeus-twitterd.pl
@@ -128,7 +128,7 @@ while(1) {
 		foreach my $short_url ($body =~ m!(https?://t\.co/[^ ]+)!g) {
 			my $response = $ua->head($short_url);
 			if ($response->is_success) {
-			    my $replacement = "$short_url <" . $response->request->uri->as_string . ">";
+			    my $replacement = "<" . $response->request->uri->as_string . ">";
 			    $body =~ s/$short_url/$replacement/;
 			}
 		}


### PR DESCRIPTION
As of 1f5bb1fa24, shortened URLs get expanded automatically. Especially when tweets contain more than one of these URLs (or images), the returned result can get quite lengthy.

There seems to be little added value in displaying both the shortened and the original URL. This pull request removes the shortened url.
